### PR TITLE
Change dependency from debathena-lert to debathena-lert-compat

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-xsession (1.22) unstable; urgency=low
+
+  * Update dependency from lert to lert-compat (Trac: #1460)
+
+ -- Jonathan Reed <jdreed@mit.edu>  Thu, 10 Apr 2014 13:12:44 -0400
+
 debathena-xsession (1.21) unstable; urgency=low
 
   * Add git-buildpackage configuration

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.3
 Package: debathena-xsession
 Architecture: all
 Depends: x11-common, zenity, debathena-pam-config, debathena-zephyr-config,
- debathena-get-message, debathena-lert, debathena-authwatch, debathena-quota,
+ debathena-get-message, debathena-lert-compat, debathena-authwatch, debathena-quota,
  debathena-mitmailutils, tcsh, xterm, gnome-session, ${misc:Depends}
 Replaces: debathena-dotfiles-x11
 Conflicts: debathena-dotfiles-x11, debathena-dotfiles (<< 10.0.2-0debathena3)


### PR DESCRIPTION
debathena-lert-compat replaces lert (Trac: #1460)
