### PR TITLE
Add Upstart session support

### DIFF
--- a/debian/00debathena-athena-session
+++ b/debian/00debathena-athena-session
@@ -1,0 +1,18 @@
+# This fixes the variable names lightdm sets for us,
+# so we appear to be a regular Ubuntu session.
+# This should be run as early as possible in Xsession.d
+#
+# DESKTOP_SESSION will be the name of the .desktop file
+# GDMSESSION is mostly unused but will also be the same value
+#
+if [ -e /etc/upstart-xsessions ] && \
+    [ "$DESKTOP_SESSION" = "athena" ]; then
+    # Pretend we're an Ubuntu session
+    export DESKTOP_SESSION=ubuntu
+    export GDMSESSION=ubuntu
+    # This should normally be set by "X-LightDM-DesktopName=Unity"
+    # in the xsession's .desktop file.
+    if [ -z "$XDG_CURRENT_DESKTOP" ]; then
+	export XDG_CURRENT_DESKTOP=Unity
+    fi
+fi

--- a/debian/00upstart-debathena
+++ b/debian/00upstart-debathena
@@ -1,0 +1,8 @@
+# This is run immediately after "00upstart" which sets
+# BASESESSION to the basename of $1 (which is the Exec=
+# line from the session's .desktop file)
+#
+if [ "$UPSTART" = "1" ] && \
+    [ "$BASESESSION" = "athena-session" ]; then
+    BASESESSION=gnome-session
+fi

--- a/debian/21debathena-fix-startup
+++ b/debian/21debathena-fix-startup
@@ -1,0 +1,11 @@
+# STARTUP is normally set to $1 (the Exec= line in the
+# .desktop file).  We reset it to gnome-session, in our
+# continued effort to emulate an Ubuntu session.
+#
+# Note that if you use full paths in the .desktop file
+# this won't work.  Don't do that.
+#
+if [ "$UPSTART" = "1" ] && \
+    [ "$STARTUP" = "athena-session" ]; then
+    STARTUP="gnome-session"
+fi

--- a/debian/99upstart-debathena
+++ b/debian/99upstart-debathena
@@ -1,0 +1,7 @@
+# This is run after 99upstart, to wrap the session
+# in our xsession code
+#
+if [ "$STARTUP" = "init --user" ] && \
+    [ -e /etc/X11/Xsession.d/98debathena-xsession ]; then
+    . /etc/X11/Xsession.d/98debathena-xsession
+fi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-xsession (1.23) unstable; urgency=low
+
+  * Add support for Upstart sessions (Trac: #1238)
+
+ -- Jonathan Reed <jdreed@mit.edu>  Mon, 19 May 2014 16:26:00 -0400
+
 debathena-xsession (1.22) unstable; urgency=low
 
   * Update dependency from lert to lert-compat (Trac: #1460)

--- a/debian/debathena-xsession.install
+++ b/debian/debathena-xsession.install
@@ -1,5 +1,6 @@
 debian/000debathena-nocalls.desktop usr/share/xsessions
 debian/001debathena-ttymode.desktop usr/share/xsessions
+debian/00debathena-athena-session etc/X11/Xsession.d
 debian/00debathena-check-afs etc/X11/Xsession.d
 debian/debathena-check-afs.sh usr/share/debathena-xsession
 debian/00debathena-message etc/X11/Xsession.d
@@ -8,8 +9,10 @@ debian/00debathena-gdm-sucks etc/X11/Xsession.d
 debian/debathena-gdm-sucks.sh usr/share/debathena-xsession
 debian/00debathena-tcsh-sucks etc/X11/Xsession.d
 debian/debathena-tcsh-sucks.sh usr/share/debathena-xsession
+debian/00upstart-debathena etc/X11/Xsession.d
 debian/01debathena-quota etc/X11/Xsession.d
 debian/debathena-quota.sh usr/share/debathena-xsession
+debian/21debathena-fix-startup etc/X11/Xsession.d
 debian/05debathena-nocalls etc/X11/Xsession.d
 debian/debathena-nocalls.sh usr/share/debathena-xsession
 debian/96debathena-tracker etc/X11/Xsession.d
@@ -17,6 +20,7 @@ debian/debathena-tracker.sh usr/share/debathena-xsession
 debian/97debathena-homedir-mode etc/X11/Xsession.d
 debian/debathena-homedir-mode.sh usr/share/debathena-xsession
 debian/98debathena-xsession etc/X11/Xsession.d
+debian/99upstart-debathena etc/X11/Xsession.d
 debian/athena-initial-x-terminal.desktop etc/xdg/autostart
 debian/displaylert usr/lib/init
 debian/displaymotd usr/lib/init


### PR DESCRIPTION
This adds support for upstart user sessions.  Specifically, we
change DESKTOP_SESSION and GDMSESSION and BASESESSION to look like
the "ubuntu" session.  We conditionalize on the existence of
/etc/upstart-xsessions and UPSTART=1 in the Xsession.d environment
