### PR TITLE
Check for our unity first-run flag

### DIFF
--- a/debian/98debathena-xsession
+++ b/debian/98debathena-xsession
@@ -10,6 +10,13 @@ if [ -x /usr/lib/init/xsession.bash ] && \
    [ -x /usr/lib/init/xsession.tcsh ] && \
      [ afs = "$DEBATHENA_HOME_TYPE" -a ! -e "$USERXSESSION" \
      -a ! -e "$ALTUSERXSESSION" ]; then
+  # Workaround for LP #1328677 and Trac #1481
+  if [ -e "${XDG_CONFIG_HOME:-$HOME/.config}/debathena/unity-first-run.stamp" ]; then
+      unitycache="${XDG_CACHE_HOME:-$HOME/.cache}/unity"
+      mkdir -p "$unitycache"
+      touch "${unitycache}/first_run.stamp"
+  fi
+
   case $SHELL in
   */bash)
     STARTUP="/usr/lib/init/xsession.bash $STARTUP"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+debathena-xsession (1.25) unstable; urgency=low
+
+  * Add unity-logout-watcher via an xdg-autostart file, which looks for
+    the unity first run stamp, and stamps our own file in XDG_CONFIG_HOME
+  * Modify 98debathena-xsession to check for our workaround for
+    Unity's first-run stamp (Trac: #1481)
+  * Depend on python-dbus and python-gobject
+
+ -- Jonathan Reed <jdreed@mit.edu>  Sat, 05 Jul 2014 17:05:25 -0400
+
 debathena-xsession (1.24) unstable; urgency=low
 
   * Convert rules file to dh7

--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,8 @@ Depends: x11-common,
  xterm,
  gnome-session,
  debathena-dconf-config,
+ python-dbus,
+ python-gobject,
  ${misc:Depends}
 Replaces: debathena-dotfiles-x11
 Conflicts: debathena-dotfiles-x11, debathena-dotfiles (<< 10.0.2-0debathena3)

--- a/debian/debathena-xsession.install
+++ b/debian/debathena-xsession.install
@@ -28,3 +28,5 @@ debian/initial-x-terminal usr/lib/init
 debian/quotawarn usr/lib/init
 debian/xsession.bash usr/lib/init
 debian/xsession.tcsh usr/lib/init
+debian/unity-logout-watcher.desktop etc/xdg/autostart
+debian/unity-logout-watcher usr/lib/init

--- a/debian/unity-logout-watcher
+++ b/debian/unity-logout-watcher
@@ -1,0 +1,76 @@
+#!/usr/bin/python -Wall
+
+import dbus
+import dbus.mainloop.glib
+import gobject
+import os
+import sys
+
+SM_DBUS_NAME = "org.gnome.SessionManager"
+SM_DBUS_PATH = "/org/gnome/SessionManager"
+SM_DBUS_INTERFACE = "org.gnome.SessionManager"
+SM_CLIENT_DBUS_INTERFACE = "org.gnome.SessionManager.ClientPrivate"
+APP_ID = "unity-logout-watcher"
+
+def unity_first_run_stamp():
+    """ Fix for Trac #1481 / LP# 1328677"""
+    home = os.getenv('HOME', None)
+    if home is None:
+        print >>sys.stderr, "unity-logout-watcher: HOME is unset.  WTF?"
+        return None
+    xdgcache = os.getenv('XDG_CACHE_HOME', os.path.join(home, '.cache'))
+    xdgconfig = os.getenv('XDG_CONFIG_HOME', os.path.join(home, '.config'))
+    try:
+        if os.path.exists(os.path.join(xdgcache, "unity/first_run.stamp")):
+            dirname = os.path.join(xdgconfig, 'debathena')
+            if not os.path.isdir(dirname):
+                os.makedirs(dirname)
+            open(os.path.join(dirname, 'unity-first-run.stamp'),
+                 'a').close()
+    except OSError as e:
+        print >>sys.stderr, "unity-logout-watcher: ", \
+            "error while creating flag file", e
+
+class Watcher:
+    def __init__(self, loop):
+        self.loop = loop
+        self.sessionBus = dbus.SessionBus()
+        try:
+            self.register_with_sm()
+            self.init_sm_client()
+        except:
+            print >>sys.stderr, "unity-logout-watcher:", \
+                "Cannot register with session manager."
+
+    # Connect to the session manager, and register our client.
+    def register_with_sm(self):
+        proxy = self.sessionBus.get_object(SM_DBUS_NAME, SM_DBUS_PATH)
+        sm = dbus.Interface(proxy, SM_DBUS_INTERFACE)
+        autostart_id = os.getenv("DESKTOP_AUTOSTART_ID", default="")
+        self.smClientId = sm.RegisterClient(APP_ID, autostart_id)
+
+    # Set up to handle signals from the session manager.
+    def init_sm_client(self):
+        proxy = self.sessionBus.get_object(SM_DBUS_NAME, self.smClientId)
+        self.smClient = dbus.Interface(proxy, SM_CLIENT_DBUS_INTERFACE)
+        self.smClient.connect_to_signal("EndSession", self.sm_on_EndSession)
+        self.smClient.connect_to_signal("Stop", self.sm_on_Stop)
+
+    # Here on an EndSession signal from the session manager.
+    def sm_on_EndSession(self, flags):
+        unity_first_run_stamp()
+        # Response args: is_ok, reason.
+        self.smClient.EndSessionResponse(True, "")
+
+    # Here on a Stop signal from the session manager.
+    def sm_on_Stop(self):
+        self.loop.quit()
+
+def main():
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    loop = gobject.MainLoop()
+    Watcher(loop)
+    loop.run()
+
+if __name__ == '__main__':
+    main()

--- a/debian/unity-logout-watcher.desktop
+++ b/debian/unity-logout-watcher.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Unity Logout Watcher
+Comment=Watch for logouts and handle Unity first-run stamp
+Icon=gnome-settings
+Exec=/usr/lib/init/unity-logout-watcher
+Terminal=false
+Type=Application
+X-GNOME-Autostart-Delay=3


### PR DESCRIPTION
- Check for our new unity first-run flag and pre-populate
  $XDG_CACHE_HOME/unity with a first-run stamp file, if we've
  already run Unity before.
  Workaround for LP: #1328677 and (Trac: #1481)
