### PR TITLE
Restore user-defined xsessions

### DIFF
--- a/debian/athena-xsession.desktop
+++ b/debian/athena-xsession.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Name=Athena: User-defined Session
+Comment=Custom ~/.xsession script
+Exec=default

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-xsession (1.27) unstable; urgency=low
+
+  * Restore per-user xsessions (Trac: #1525)
+
+ -- Jonathan Reed <jdreed@mit.edu>  Fri, 12 Sep 2014 15:01:26 -0400
+
 debathena-xsession (1.26) unstable; urgency=low
 
   * Depend on the new debathena-account-repair package

--- a/debian/debathena-xsession.install
+++ b/debian/debathena-xsession.install
@@ -30,3 +30,4 @@ debian/xsession.bash usr/lib/init
 debian/xsession.tcsh usr/lib/init
 debian/unity-logout-watcher.desktop etc/xdg/autostart
 debian/unity-logout-watcher usr/lib/init
+debian/athena-xsession.desktop usr/share/xsessions


### PR DESCRIPTION
Per (Trac: #1525), restore user-defined xsessions, which were
only present in older releases because gdm.  To avoid stupid
build-time dependencies, we'll just ship our own, and name it
ourselves.
